### PR TITLE
Add GitHub CLI as a dependency of gh-dash

### DIFF
--- a/Formula/gh-dash.rb
+++ b/Formula/gh-dash.rb
@@ -3,7 +3,6 @@ class GhDash < Formula
   homepage "https://dlvhdr.github.io/gh-dash"
   version "4.7.3"
   license "MIT"
-
   depends_on "gh"
 
   on_macos do

--- a/Formula/gh-dash.rb
+++ b/Formula/gh-dash.rb
@@ -4,6 +4,8 @@ class GhDash < Formula
   version "4.7.3"
   license "MIT"
 
+  depends_on "gh"
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/dlvhdr/gh-dash/releases/download/v4.7.3/gh-dash_v4.7.3_darwin-amd64"


### PR DESCRIPTION
gh-dash requires GitHub CLI (gh) to run correctly.